### PR TITLE
modify package references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ jobs:
             yarn build
       - persist_to_workspace:
           root: ~/user-agents
-          paths:
           <<: *whitelist
 
   test:
@@ -102,7 +101,6 @@ jobs:
             yarn update-data
       - persist_to_workspace:
           root: ~/user-agents
-          paths:
           <<: *whitelist
 
   publish-new-version:
@@ -188,7 +186,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - monibrand-version
 
     jobs:
       - checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributions are welcome, but please follow these contributor guidelines:
 
-- Create an issue on [the issue tracker](https://github.com/intoli/user-agents/issues/new) to discuss potential changes before submitting a pull request.
+- Create an issue on [the issue tracker](https://github.com/monibrand/user-agents/issues/new) to discuss potential changes before submitting a pull request.
 - Include at least one test to cover any new functionality or bug fixes.
 - Make sure that all of your tests are passing and that there are no merge conflicts.
-- You agree to sign the project's [Contributor License Agreement](https://www.clahub.com/agreements/intoli/user-agents).
+- You agree to sign the project's [Contributor License Agreement](https://www.clahub.com/agreements/monibrand/user-agents).

--- a/README.md
+++ b/README.md
@@ -3,29 +3,29 @@
 </h1>
 
 <p align="left">
-    <a href="https://circleci.com/gh/intoli/user-agents/tree/master">
-        <img src="https://img.shields.io/circleci/project/github/intoli/user-agents/master.svg"
+    <a href="https://circleci.com/gh/monibrand/user-agents/tree/master">
+        <img src="https://img.shields.io/circleci/project/github/monibrand/user-agents/master.svg"
             alt="Build Status"></a>
-    <a href="https://circleci.com/gh/intoli/user-agents/tree/master">
-        <img src="https://img.shields.io/github/last-commit/intoli/user-agents/master.svg"
+    <a href="https://circleci.com/gh/monibrand/user-agents/tree/master">
+        <img src="https://img.shields.io/github/last-commit/monibrand/user-agents/master.svg"
             alt="Build Status"></a>
-    <a href="https://github.com/intoli/user-agents/blob/master/LICENSE">
+    <a href="https://github.com/monibrand/user-agents/blob/master/LICENSE">
         <img src="https://img.shields.io/badge/License-BSD%202--Clause-blue.svg"
             alt="License"></a>
     <a href="https://www.npmjs.com/package/user-agents">
         <img src="https://img.shields.io/npm/v/user-agents.svg"
             alt="NPM Version"></a>
     <span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-    <a target="_blank" href="https://twitter.com/home?status=User%20Agents%20is%20a%20JavaScript%20module%20for%20generating%20random%20user%20agents%20that's%20updated%20daily%20with%20new%20market%20share%20data.%0A%0Ahttps%3A//github.com/intoli/user-agents">
+    <a target="_blank" href="https://twitter.com/home?status=User%20Agents%20is%20a%20JavaScript%20module%20for%20generating%20random%20user%20agents%20that's%20updated%20daily%20with%20new%20market%20share%20data.%0A%0Ahttps%3A//github.com/monibrand/user-agents">
         <img height="26px" src="https://simplesharebuttons.com/images/somacro/twitter.png"
             alt="Tweet"></a>
-    <a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/intoli/user-agents">
+    <a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A//github.com/monibrand/user-agents">
         <img height="26px" src="https://simplesharebuttons.com/images/somacro/facebook.png"
             alt="Share on Facebook"></a>
     <a target="_blank" href="http://reddit.com/submit?url=https%3A%2F%2Fgithub.com%2Fintoli%2Fuser-agents&title=User%20Agents%20-%20Random%20user%20agent%20generation%20with%20daily-updated%20market%20share%20data">
         <img height="26px" src="https://simplesharebuttons.com/images/somacro/reddit.png"
             alt="Share on Reddit"></a>
-    <a target="_blank" href="https://news.ycombinator.com/submitlink?u=https://github.com/intoli/user-agents&t=User%20Agents%20-%20Random%20user%20agent%20generation%20with%20daily-updated%20market%20share%20data">
+    <a target="_blank" href="https://news.ycombinator.com/submitlink?u=https://github.com/monibrand/user-agents&t=User%20Agents%20-%20Random%20user%20agent%20generation%20with%20daily-updated%20market%20share%20data">
         <img height="26px" src="media/ycombinator.png"
             alt="Share on Hacker News"></a>
 </p>
@@ -72,7 +72,7 @@ It will be automatically populated with a random user agent and browser fingerpr
 
 
 ```javascript
-import UserAgent from 'user-agents';
+import UserAgent from '@monibrand/user-agents';
 
 
 const userAgent = new UserAgent();
@@ -116,7 +116,7 @@ The `data` property includes a randomly generated browser fingerprint that can b
 By passing an object as a filter, each corresponding user agent property will be restricted based on its values.
 
 ```javascript
-import UserAgent from 'user-agents';
+import UserAgent from '@monibrand/user-agents';
 
 const userAgent = new UserAgent({ deviceCategory: 'mobile' })
 ```
@@ -131,7 +131,7 @@ There is some computational overhead involved with applying a set of filters, so
 You can call any initialized `UserAgent` instance like a function, and it will generate a new random instance with the same filters (you can also call `userAgent.random()` if you're not a fan of the shorthand).
 
 ```javascript
-import UserAgent from 'user-agents';
+import UserAgent from '@monibrand/user-agents';
 
 const userAgent = new UserAgent({ platform: 'Win32' });
 const userAgents = Array(1000).fill().map(() => userAgent());
@@ -145,7 +145,7 @@ This code example initializes a single user agent with a filter that limits the 
 You can pass a regular expression as a filter and the generated user agent will be guaranteed to match that regular expression.
 
 ```javascript
-import UserAgent from 'user-agents';
+import UserAgent from '@monibrand/user-agents';
 
 const userAgent = new UserAgent(/Safari/);
 ```
@@ -160,7 +160,7 @@ The raw `userAgent.data` object will be passed into your function, and it will b
 In this example, we'll use the [useragent](https://www.npmjs.com/package/useragent) package to parse the user agent string and then restrict the generated user agents to iOS devices with an operating system version of 11 or greater.
 
 ```javascript
-import UserAgent from 'user-agents';
+import UserAgent from '@monibrand/user-agents';
 import { parse } from 'useragent';
 
 const userAgent = new UserAgent((data) => {
@@ -178,7 +178,7 @@ You can also use arrays to specify collections of filters that will all be appli
 This example combines a regular expression filter with an object filter to generate a user agent with a connection type of `wifi`, a platform of `MacIntel`, and a user agent that includes a `Safari` substring.
 
 ```javascript
-import UserAgent from 'user-agents';
+import UserAgent from '@monibrand/user-agents';
 
 const userAgent = new UserAgent([
   /Safari/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "user-agents",
+  "name": "@monibrand/user-agents",
   "version": "1.0.559",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
A large part in the original packages' appeal was the repository's ability to stay updated, with automated releases for scheduled checks. Read in [Collecting the data](https://intoli.com/blog/user-agents/) section of his article.

For this you will have to set up CircleCI for this fork complete with environment variables:
- [`NPM_TOKEN`](https://www.npmjs.com/settings/monibrand/tokens)
- `GOOGLE_ANALYTICS_CREDENTIALS` - Creating service account credentials [explanation included in the article](https://intoli.com/blog/user-agents/)

This will allow this fork to become a replacement for the original package